### PR TITLE
Layout: Tabela de pedidos

### DIFF
--- a/app/assets/stylesheets/order_clients.scss
+++ b/app/assets/stylesheets/order_clients.scss
@@ -26,6 +26,16 @@
   text-decoration: none;
 }
 
+/* Link para o cliente cancelar pedido */
+.link-cancel-order a {
+  color: gray;
+  text-decoration: none;
+}
+
+.link-cancel-order a:hover {
+  color: red;
+}
+
 /* Indica pedido aceito */
 .status-accepted {
    color: green;

--- a/app/views/client/order_clients/index.html.erb
+++ b/app/views/client/order_clients/index.html.erb
@@ -1,5 +1,1 @@
-<h1>Meus Pedidos</h1>
-<% if @order_clients.empty?%>
-  <p><%= 'Você não possui pedidos'%><p>
-<% end %>
 <%= render 'shared/orders' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,8 +27,8 @@
           <% end %>
           <% if client_signed_in? %>
             <li><%= link_to 'Minha conta', current_client.company %></li>
-            <li><%= link_to t('.sign_out'), destroy_client_session_path, method: :delete %></li>
             <li><%= link_to 'Meus Pedidos', client_order_clients_path %></li>
+            <li><%= link_to t('.sign_out'), destroy_client_session_path, method: :delete %></li>
           <% end %>
         <% else %>
           <li><%= link_to t('.employee_sign_in'), new_employee_session_path %></li>

--- a/app/views/order_clients/index.html.erb
+++ b/app/views/order_clients/index.html.erb
@@ -1,5 +1,1 @@
-<h1>Pedidos</h1>
-<% if @order_clients.empty?%>
-  <p><%= 'Nenhum pedido cadastrado'%><p>
-<% end %>
 <%= render 'shared/orders' %>

--- a/app/views/order_clients/show.html.erb
+++ b/app/views/order_clients/show.html.erb
@@ -29,13 +29,15 @@
       <% end %>
     </ul>
 
-    <p class="btn btn-success approved-order">
-      <%= link_to 'Aprovar Pedido', order_client_approved_orders_path(@order_client), method: :post %>
-    </p> 
+    <% if employee_signed_in? %>
+      <p class="btn btn-success approved-order">
+        <%= link_to 'Aprovar Pedido', order_client_approved_orders_path(@order_client), method: :post %>
+      </p> 
 
-    <p class="btn btn-danger rejected-order">
-      <%= link_to 'Reprovar Pedido', new_order_client_rejected_order_path(@order_client) %>
-    </p>
+      <p class="btn btn-danger rejected-order">
+        <%= link_to 'Reprovar Pedido', new_order_client_rejected_order_path(@order_client) %>
+      </p>
+    <% end %>
   </div>
 
   <div>

--- a/app/views/shared/_orders.html.erb
+++ b/app/views/shared/_orders.html.erb
@@ -1,41 +1,58 @@
-<h2>Lista de Pedidos</h2>
-<table class="table table-hover">
-  <thead>
-    <tr>
-      <th scope="col">#</th>
-      <th scope="col">Token da Empresa</th>
-      <th scope="col">Plano</th>
-      <th scope="col">Status</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @order_clients.each do |order| %>
-      <tr>
-        <th scope="row"><%= order.id %></th>
-        <td ><%= link_to order.token, order %></td>
-        <td><%= order.plan %></td>
-        <% if client_signed_in? %>
-          <% if order.waiting? %>
-            <td><%= link_to 'Cancelar Pedido', cancel_client_order_client_path(order),
+<div class="table-order-clients">
+  <% if @order_clients.empty? %>
+    <div class="without-order-clients">
+      <div><%= image_tag("empty.svg", size: "300x300", alt: "")%></div>
+      <% if client_signed_in? %>
+        <h3>Você não possui pedidos</h3>
+      <% else %>
+        <h3>Nenhum pedido cadastrado</h3>
+      <% end %>
+    </div>
+  <% else %>
+    <h2>Lista de Pedidos</h2>
+    <table class="table table-hover">
+      <thead>
+        <tr>
+          <th scope="col">#</th>
+          <th scope="col"><%= OrderClient.human_attribute_name(:token) %></th>
+          <th scope="col"><%= OrderClient.human_attribute_name(:plan) %></th>
+          <th scope="col"><%= Client.human_attribute_name(:email) %></th>
+          <th scope="col"><%= OrderClient.human_attribute_name(:status) %></th>
+          <% if client_signed_in? %>
+            <th scope="col">Cancelamento</th>
+          <% end %>
+        </tr>
+      </thead>
+      <tbody>
+        <% @order_clients.each do |order| %>
+          <tr>
+            <th scope="row"><%= order.id %></th>
+            <td ><%= link_to order.token, order %></td>
+            <td><%= order.plan %></td>
+            <td><%= order.client.email %></td>
+            <% if order.accepted? %>
+              <td><strong class="status-accepted">
+                <%= OrderClient.human_attribute_name("status.#{order.status}") %>
+              </strong></td>
+            <% elsif order.rejected? %>
+              <td><strong class="status-rejected">
+                <%= OrderClient.human_attribute_name("status.#{order.status}") %>
+              </strong></td>
+            <% else %>
+              <td><strong>
+                <%= OrderClient.human_attribute_name("status.#{order.status}") %>
+              </strong></td>
+            <% end %>
+            <% if client_signed_in? %>
+              <% if order.waiting? %>
+                <td class="link-cancel-order"><%= link_to 'Cancelar Pedido', cancel_client_order_client_path(order),
                                 id:"cancel-#{order.id}",
                                 method: :post  %></td>
-          <% end %>
+              <% end %>
+            <% end %>
+          </tr>
         <% end %>
-        <% if order.accepted? %>
-          <td><strong class="status-accepted">
-            <%= OrderClient.human_attribute_name("status.#{order.status}") %>
-          </strong></td>
-        <% else %>
-          <td><strong>
-            <%= OrderClient.human_attribute_name("status.#{order.status}") %>
-          </strong></td>
-        <% end %>
-        <% if order.rejected? %>
-          <td><strong class="status-rejected">
-          <%= OrderClient.human_attribute_name("status.#{order.status}") %>
-          </strong></td>
-        <% end %>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+      </tbody>
+    </table>
+  <% end %>
+</div>

--- a/app/views/shared/_orders.html.erb
+++ b/app/views/shared/_orders.html.erb
@@ -1,22 +1,41 @@
-<% @order_clients.each do |order|%> 
-  <dl>
-    <dt><%= OrderClient.human_attribute_name(:token)   %></dt>
-      <dd><%= link_to order.token, order %></dd>
-    <dt><%= OrderClient.human_attribute_name(:plan)   %></dt>
-      <dd><%= order.plan %></dd>
-    <dt><%= OrderClient.human_attribute_name(:plan_id) %>: </dt>
-      <dd><%= order.plan_id %></dd>
-    <dt><%= Client.human_attribute_name(:email) %>: </dt>
-      <dd><%= order.client.email %></dd>
-    <dt><%= OrderClient.human_attribute_name(:status) %>: </dt>
-    <dd><%= OrderClient.human_attribute_name("status.#{order.status}") %></dd>
-    <% if client_signed_in? %>
-      <% if order.waiting? %>
-      <%= link_to 'Cancelar Pedido', cancel_client_order_client_path(order),
-                                  id:"cancel-#{order.id}",
-                                  method: :post  %>
-      <% end %>
+<h2>Lista de Pedidos</h2>
+<table class="table table-hover">
+  <thead>
+    <tr>
+      <th scope="col">#</th>
+      <th scope="col">Token da Empresa</th>
+      <th scope="col">Plano</th>
+      <th scope="col">Status</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @order_clients.each do |order| %>
+      <tr>
+        <th scope="row"><%= order.id %></th>
+        <td ><%= link_to order.token, order %></td>
+        <td><%= order.plan %></td>
+        <% if client_signed_in? %>
+          <% if order.waiting? %>
+            <td><%= link_to 'Cancelar Pedido', cancel_client_order_client_path(order),
+                                id:"cancel-#{order.id}",
+                                method: :post  %></td>
+          <% end %>
+        <% end %>
+        <% if order.accepted? %>
+          <td><strong class="status-accepted">
+            <%= OrderClient.human_attribute_name("status.#{order.status}") %>
+          </strong></td>
+        <% else %>
+          <td><strong>
+            <%= OrderClient.human_attribute_name("status.#{order.status}") %>
+          </strong></td>
+        <% end %>
+        <% if order.rejected? %>
+          <td><strong class="status-rejected">
+          <%= OrderClient.human_attribute_name("status.#{order.status}") %>
+          </strong></td>
+        <% end %>
+      </tr>
     <% end %>
-  </dl>
-<br>
-<% end %>
+  </tbody>
+</table>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,18 +1,16 @@
 require 'faker'
 
 #Vendedores
-first_employee = Employee.create(email: 'first@teste.com', password: '123456')
-Employee.create(email: 'second@teste.com', password: '123456')
-Employee.create(email: 'third@teste.com', password: '123456')
+FactoryBot.create(:employee, email: 'first@teste.com')
+FactoryBot.create(:employee, email: 'second@teste.com')
+FactoryBot.create(:employee, email: 'third@teste.com')
 
 #Pedidos
-10.times do |this|
-	OrderClient.create(token: Faker::Code.nric, plan: Faker::Name.name)
-end
+FactoryBot.create_list(:order_client, 10)
 
 #Pedidos aprovados
-ApprovedOrder.create(order_client_id: OrderClient.first.id)
-ApprovedOrder.create(order_client_id: OrderClient.last.id)
+FactoryBot.create(:approved_order, order_client: OrderClient.first)
+FactoryBot.create(:approved_order, order_client: OrderClient.last)
 
 #Clientes
 client_one = Client.create!(email: 'cliente01@email.com', password: '12345678')

--- a/spec/features/employee/approve_order_spec.rb
+++ b/spec/features/employee/approve_order_spec.rb
@@ -11,8 +11,8 @@ feature 'Employee view orders' do
     expect(current_path).to eq(order_clients_path)
     expect(page).to have_content(order.token)
     expect(page).to have_content(order.plan)
-    expect(page).to have_content('Status: Em aberto')
-    expect(page).not_to have_content('Status: Aprovado')
+    expect(page).to have_content('Em aberto')
+    expect(page).not_to have_content('Aprovado')
   end
 
   scenario 'and view details' do
@@ -24,8 +24,8 @@ feature 'Employee view orders' do
 
     expect(page).to have_content(order.token)
     expect(page).to have_content(order.plan)
-    expect(page).to have_content('Status: Em aberto')
-    expect(page).not_to have_content('Status: Aprovado')
+    expect(page).to have_content('Em aberto')
+    expect(page).not_to have_content('Aprovado')
     expect(page).to have_link('Aprovar Pedido', href: order_client_approved_orders_path(order.id))
   end
 


### PR DESCRIPTION
<h2>Motivação</h2>

Ao mergear a [PR](https://github.com/TreinaDev/checkout_area_do_cliente/pull/41) para cancelamento de pedidos pelo cliente o layout da tabela de pedidos não foi salvo.

Por este PR, o objetivo foi retornar o layout feito na [PR](https://github.com/TreinaDev/checkout_area_do_cliente/pull/56) de layout dos pedidos e **unir** com o que foi feito na PR de cancelamento como mostrar o email do cliente, usar I18n para os titulos e link para que os clientes possam cancelar os seus pedidos. 

<h2>Comentários</h2>

Na rota show de pedidos, usei um if para permitir que **somente os vendedores** possam ter acesso aos link de aprovar e reprovar pedido, e acredito que poderiamos escrever um teste posteriormente. 

Reparei que quando o cliente faz um pedido, as informações do **plano e token da empresa não aparecem na tela** e que o cliente **pode acessar todos os pedidos do sistema e cancelar pedidos que não são dele**, porem, este PR tem o objetivo de corrigir **apenas** o layout. Poderiamos ver essas questões em outro PR. 

<h2>Layout Atual</h2>

![bug3=pedidos](https://user-images.githubusercontent.com/46378210/87061520-3be73800-c1e2-11ea-8428-9ccd79d50c6d.png)

![cancelar](https://user-images.githubusercontent.com/46378210/87061525-3d186500-c1e2-11ea-9469-25b127b38001.png)

![bug-compra](https://user-images.githubusercontent.com/46378210/87061784-94b6d080-c1e2-11ea-9562-4907923279bc.png)

